### PR TITLE
Fixed ClassCastException

### DIFF
--- a/src/main/java/pam/pamhc2crops/items/ItemPamGrain.java
+++ b/src/main/java/pam/pamhc2crops/items/ItemPamGrain.java
@@ -28,38 +28,40 @@ public class ItemPamGrain extends BlockNamedItem {
 	public boolean itemInteractionForEntity(ItemStack itemstack, PlayerEntity player,
 			LivingEntity entity, Hand hand) {
 
-		ItemStack stack = player.getHeldItem(hand);
+		if (entity instanceof AgeableEntity) {
+			ItemStack stack = player.getHeldItem(hand);
 
-		if (!entity.world.isRemote && !entity.isChild() && entity instanceof AgeableEntity && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
-			if (entity instanceof CowEntity) {
-				if (((CowEntity) entity).isInLove()) {
-					return false;
-				} else {
-					((CowEntity) entity).setInLove(player);
-					if (!player.isCreative())
-						stack.shrink(1);
-					return true;
+			if (!entity.world.isRemote && !entity.isChild() && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
+				if (entity instanceof CowEntity) {
+					if (((CowEntity) entity).isInLove()) {
+						return false;
+					} else {
+						((CowEntity) entity).setInLove(player);
+						if (!player.isCreative())
+							stack.shrink(1);
+						return true;
+					}
+				}
+
+				if (entity instanceof SheepEntity) {
+					if (((SheepEntity) entity).isInLove()) {
+						return false;
+					} else {
+						((SheepEntity) entity).setInLove(player);
+						if (!player.isCreative())
+							stack.shrink(1);
+						return true;
+					}
 				}
 			}
 
-			if (entity instanceof SheepEntity) {
-				if (((SheepEntity) entity).isInLove()) {
-					return false;
-				} else {
-					((SheepEntity) entity).setInLove(player);
-					if (!player.isCreative())
-						stack.shrink(1);
-					return true;
-				}
+			if (entity.isChild()) {
+				if (!player.isCreative())
+					stack.shrink(1);
+				((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
+						true);
+				return true;
 			}
-		}
-
-		if (entity.isChild()) {
-			if (!player.isCreative())
-				stack.shrink(1);
-			((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
-					true);
-			return true;
 		}
 
 		return false;

--- a/src/main/java/pam/pamhc2crops/items/ItemPamPig.java
+++ b/src/main/java/pam/pamhc2crops/items/ItemPamPig.java
@@ -27,29 +27,31 @@ public class ItemPamPig extends BlockNamedItem {
 	public boolean itemInteractionForEntity(ItemStack itemstack, PlayerEntity player,
 			LivingEntity entity, Hand hand) {
 
-		ItemStack stack = player.getHeldItem(hand);
+		if (entity instanceof AgeableEntity) {
+			ItemStack stack = player.getHeldItem(hand);
 
-		if (!entity.world.isRemote && !entity.isChild() && entity instanceof AgeableEntity && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
-			if (entity instanceof PigEntity) {
-				if (((PigEntity) entity).isInLove()) {
-					return false;
-				} else {
-					((PigEntity) entity).setInLove(player);
-					if (!player.isCreative())
-						stack.shrink(1);
-					return true;
+			if (!entity.world.isRemote && !entity.isChild() && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
+				if (entity instanceof PigEntity) {
+					if (((PigEntity) entity).isInLove()) {
+						return false;
+					} else {
+						((PigEntity) entity).setInLove(player);
+						if (!player.isCreative())
+							stack.shrink(1);
+						return true;
+					}
+
 				}
 
 			}
 
-		}
-
-		if (entity.isChild()) {
-			if (!player.isCreative())
-				stack.shrink(1);
-			((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
-					true);
-			return true;
+			if (entity.isChild()) {
+				if (!player.isCreative())
+					stack.shrink(1);
+				((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
+						true);
+				return true;
+			}
 		}
 
 		return false;

--- a/src/main/java/pam/pamhc2crops/items/ItemPamRabbit.java
+++ b/src/main/java/pam/pamhc2crops/items/ItemPamRabbit.java
@@ -27,29 +27,31 @@ public class ItemPamRabbit extends BlockNamedItem {
 	public boolean itemInteractionForEntity(ItemStack itemstack, PlayerEntity player,
 			LivingEntity entity, Hand hand) {
 
-		ItemStack stack = player.getHeldItem(hand);
+		if (entity instanceof AgeableEntity) {
+			ItemStack stack = player.getHeldItem(hand);
 
-		if (!entity.world.isRemote && !entity.isChild() && entity instanceof AgeableEntity && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
-			if (entity instanceof RabbitEntity) {
-				if (((RabbitEntity) entity).isInLove()) {
-					return false;
-				} else {
-					((RabbitEntity) entity).setInLove(player);
-					if (!player.isCreative())
-						stack.shrink(1);
-					return true;
+			if (!entity.world.isRemote && !entity.isChild() && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
+				if (entity instanceof RabbitEntity) {
+					if (((RabbitEntity) entity).isInLove()) {
+						return false;
+					} else {
+						((RabbitEntity) entity).setInLove(player);
+						if (!player.isCreative())
+							stack.shrink(1);
+						return true;
+					}
+
 				}
 
 			}
 
-		}
-
-		if (entity.isChild()) {
-			if (!player.isCreative())
-				stack.shrink(1);
-			((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
-					true);
-			return true;
+			if (entity.isChild()) {
+				if (!player.isCreative())
+					stack.shrink(1);
+				((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
+						true);
+				return true;
+			}
 		}
 
 		return false;

--- a/src/main/java/pam/pamhc2crops/items/ItemPamSeed.java
+++ b/src/main/java/pam/pamhc2crops/items/ItemPamSeed.java
@@ -29,38 +29,40 @@ public class ItemPamSeed extends BlockNamedItem {
 	public boolean itemInteractionForEntity(ItemStack itemstack, PlayerEntity player,
 			LivingEntity entity, Hand hand) {
 
-		ItemStack stack = player.getHeldItem(hand);
+		if (entity instanceof AgeableEntity) {
+			ItemStack stack = player.getHeldItem(hand);
 
-		if (!entity.world.isRemote && !entity.isChild() && entity instanceof AgeableEntity && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
-			if (entity instanceof ChickenEntity) {
-				if (((ChickenEntity) entity).isInLove()) {
-					return false;
-				} else {
-					((ChickenEntity) entity).setInLove(player);
-					if (!player.isCreative())
-						stack.shrink(1);
-					return true;
+			if (!entity.world.isRemote && !entity.isChild() && (int) ((AgeableEntity) entity).getGrowingAge() == 0) {
+				if (entity instanceof ChickenEntity) {
+					if (((ChickenEntity) entity).isInLove()) {
+						return false;
+					} else {
+						((ChickenEntity) entity).setInLove(player);
+						if (!player.isCreative())
+							stack.shrink(1);
+						return true;
+					}
 				}
+
+				if (entity instanceof ParrotEntity)
+					if (!entity.world.isRemote) {
+						if (!((ParrotEntity) entity).isTamed())
+							if (Math.random() <= 0.33) {
+								((ParrotEntity) entity).setTamedBy(player);
+								((ParrotEntity) entity).setInLove(player);
+							}
+						if (!player.isCreative())
+							stack.shrink(1);
+					}
 			}
 
-			if (entity instanceof ParrotEntity)
-				if (!entity.world.isRemote) {
-					if (!((ParrotEntity) entity).isTamed())
-						if (Math.random() <= 0.33) {
-							((ParrotEntity) entity).setTamedBy(player);
-							((ParrotEntity) entity).setInLove(player);
-						}
-					if (!player.isCreative())
-						stack.shrink(1);
-				}
-		}
-
-		if (entity.isChild()) {
-			if (!player.isCreative())
-				stack.shrink(1);
-			((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
-					true);
-			return true;
+			if (entity.isChild()) {
+				if (!player.isCreative())
+					stack.shrink(1);
+				((AgeableEntity) entity).ageUp((int) ((float) (-((AgeableEntity) entity).getGrowingAge() / 20) * 0.1F),
+						true);
+				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
If a mob returns true for isChild but does not inherit from AgeableEntity, then right-clicking it with an ItemPamGrain, ItemPamPig, ItemPamRabbit, or ItemPamSeed will crash the game because this exception is thrown:

```
java.lang.ClassCastException: mekanism.additions.common.entity.baby.EntityBabyCreeper cannot be cast to net.minecraft.entity.AgeableEntity
	at pam.pamhc2crops.items.ItemPamRabbit.func_111207_a(ItemPamRabbit.java:51) ~[pamhc2crops:1.0.2] {re:classloading}
...
```

Mekanism Additions is one mod that will trigger this bug with its EntityBabyCreeper. Presumably all its other baby monsters have the same problem.

This PR fixes the problem by checking if the entity is an instance of AgeableEntity before casting it. I noticed that the first half of the method already does this, so I wrapped the rest of the method inside that check.